### PR TITLE
Removing depreciated autloader

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -16,7 +16,9 @@ $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 date_default_timezone_set('Europe/London');
 
 //load classes as needed
-function __autoload($class) {
+spl_autoload_register('autoloader');
+
+function autoloader($class) {
    
    $class = strtolower($class);
 


### PR DESCRIPTION
__autoload function has been DEPRECATED as of PHP 7.2.0, and REMOVED as of PHP 8.0.0